### PR TITLE
tf2 does not work for ExportModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Requirements - 
 > numpy\
 sentencepiece\
-tensorflow==2.2.0
+tensorflow==2.2.0  # This does not work.
 
 # PEGASUS library
 


### PR DESCRIPTION
Hi @TheRockXu ,

Thanks for putting this together. Raising a PR because there was no way to create an issue on your repo.
I was trying to export the original checkpoints which Pegasus provides (wanted to replicate the results as closely as possible).
This might be useful for the next person who tries to export the model :)

The Transformer blocks in the original Pegasus code use modules from contrib (which has been removed from tf2.0).
As a result, the ExportModel functionality just breaks with tf2. ==> [transformer_block](https://github.com/google-research/pegasus/blob/master/pegasus/layers/transformer_block.py#L28)

Code blocks used `layer_norm` from contrib, which could be replaced with Keras layers.
But the `contrib_training.HParams` in `pegasus/params/pegasus_params.py` does not have a replacement in tf2 ==> [params](https://github.com/google-research/pegasus/blob/master/pegasus/params/pegasus_params.py#L25).

If you ever find a workaround, do let me know.
Thanks!